### PR TITLE
Spandex RISC-V ISA Patches for Ariane

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/lowRISC/ariane-ethernet.git
 [submodule "src/axi_riscv_atomics"]
 	path = src/axi_riscv_atomics
-	url = https://github.com/sld-columbia/axi_riscv_atomics.git
+	url = git@github.com:zzhu35/axi_riscv_atomics.git
 [submodule "src/riscv-dbg"]
 	path = src/riscv-dbg
 	url = https://github.com/pulp-platform/riscv-dbg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/lowRISC/ariane-ethernet.git
 [submodule "src/axi_riscv_atomics"]
 	path = src/axi_riscv_atomics
-	url = git@github.com:zzhu35/axi_riscv_atomics.git
+	url = https://github.com/zzhu35/axi_riscv_atomics.git
 	branch = spandex
 [submodule "src/riscv-dbg"]
 	path = src/riscv-dbg

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,7 @@
 [submodule "src/axi_riscv_atomics"]
 	path = src/axi_riscv_atomics
 	url = git@github.com:zzhu35/axi_riscv_atomics.git
+	branch = spandex
 [submodule "src/riscv-dbg"]
 	path = src/riscv-dbg
 	url = https://github.com/pulp-platform/riscv-dbg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,8 +39,7 @@
 	url = https://github.com/lowRISC/ariane-ethernet.git
 [submodule "src/axi_riscv_atomics"]
 	path = src/axi_riscv_atomics
-	url = https://github.com/zzhu35/axi_riscv_atomics.git
-	branch = spandex
+	url = https://github.com/sld-columbia/axi_riscv_atomics.git
 [submodule "src/riscv-dbg"]
 	path = src/riscv-dbg
 	url = https://github.com/pulp-platform/riscv-dbg.git

--- a/include/ariane_axi_pkg.sv
+++ b/include/ariane_axi_pkg.sv
@@ -20,7 +20,7 @@ package ariane_axi;
     // used in axi_adapter.sv
     typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } ad_req_t;
 
-    localparam UserWidth = 1;
+    localparam UserWidth = 10;
     localparam AddrWidth = 64;
     localparam DataWidth = 64;
     localparam StrbWidth = DataWidth / 8;
@@ -45,6 +45,7 @@ package ariane_axi;
         axi_pkg::qos_t    qos;
         axi_pkg::region_t region;
         axi_pkg::atop_t   atop;
+        user_t            user;
     } aw_chan_t;
 
     // AW Channel - Slave
@@ -93,6 +94,7 @@ package ariane_axi;
         axi_pkg::prot_t   prot;
         axi_pkg::qos_t    qos;
         axi_pkg::region_t region;
+        user_t            user;
     } ar_chan_t;
 
     // AR Channel - Slave

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -476,6 +476,9 @@ package ariane_pkg;
         logic [63:0]              operand_b;
         logic [63:0]              imm;
         logic [TRANS_ID_BITS-1:0] trans_id;
+        logic                     use_dcs;
+        logic                     aq;
+        logic                     rl;
     } fu_data_t;
 
     function automatic logic is_branch (input fu_op op);
@@ -561,6 +564,13 @@ package ariane_pkg;
     endfunction
 
     typedef struct packed {
+        logic                     dcs_en;
+        logic                     use_owner_pred;
+        logic [1:0]               dcs;
+        logic [3:0]               cid;
+    } dcs_data_t;
+
+    typedef struct packed {
         logic                     valid;
         logic [riscv::VLEN-1:0]   vaddr;
         logic                     overflow;
@@ -569,6 +579,9 @@ package ariane_pkg;
         fu_t                      fu;
         fu_op                     operator;
         logic [TRANS_ID_BITS-1:0] trans_id;
+        dcs_data_t                dcs_data;
+        logic                     aq;
+        logic                     rl;
     } lsu_ctrl_t;
 
     // ---------------
@@ -594,6 +607,7 @@ package ariane_pkg;
         logic [REG_ADDR_SIZE-1:0] rs1;           // register source address 1
         logic [REG_ADDR_SIZE-1:0] rs2;           // register source address 2
         logic [REG_ADDR_SIZE-1:0] rd;            // register destination address
+        logic                     sync;
         logic [63:0]              result;        // for unfinished instructions this field also holds the immediate,
                                                  // for unfinished floating-point that are partly encoded in rs2, this field also holds rs2
                                                  // for unfinished floating-point fused operations (FMADD, FMSUB, FNMADD, FNMSUB)
@@ -606,6 +620,9 @@ package ariane_pkg;
         branchpredict_sbe_t       bp;            // branch predict scoreboard data structure
         logic                     is_compressed; // signals a compressed instructions, we need this information at the commit stage if
                                                  // we want jump accordingly e.g.: +4, +2
+        logic                     use_dcs;       // 1 for load/store using dcs
+        logic                     aq;
+        logic                     rl;
     } scoreboard_entry_t;
 
     // --------------------
@@ -685,6 +702,8 @@ package ariane_pkg;
         logic [1:0]  size;      // 2'b10 --> word operation, 2'b11 --> double word operation
         logic [63:0] operand_a; // address
         logic [63:0] operand_b; // data as layouted in the register
+        logic        aq;
+        logic        rl;
     } amo_req_t;
 
     // AMO response coming from cache.
@@ -704,6 +723,7 @@ package ariane_pkg;
         logic [1:0]                    data_size;
         logic                          kill_req;
         logic                          tag_valid;
+        dcs_data_t                     dcs_data;
     } dcache_req_i_t;
 
     typedef struct packed {

--- a/include/wt_cache_pkg.sv
+++ b/include/wt_cache_pkg.sv
@@ -82,6 +82,7 @@ package wt_cache_pkg;
     logic [7:0]                                                             txblock; // byte is part of transaction in-flight
     logic                                                                   checked; // if cache state of this word has been checked
     logic [ariane_pkg::DCACHE_SET_ASSOC-1:0]                                hit_oh;  // valid way in the cache
+    ariane_pkg::dcs_data_t                                                  dcs_data;
   } wbuffer_t;
 
   // TX status registers are indexed with the transaction ID
@@ -146,6 +147,9 @@ package wt_cache_pkg;
     logic                                            nc;          // noncacheable
     logic [CACHE_ID_WIDTH-1:0]                       tid;         // threadi id (used as transaction id in Ariane)
     ariane_pkg::amo_t                                amo_op;      // amo opcode
+    ariane_pkg::dcs_data_t                           dcs_data;
+    logic                                            aq;
+    logic                                            rl;
   } dcache_req_t;
 
   typedef struct packed {

--- a/src/amo_buffer.sv
+++ b/src/amo_buffer.sv
@@ -25,6 +25,8 @@ module amo_buffer (
     input  logic [riscv::PLEN-1:0]      paddr_i,            // physical address of store which needs to be placed in the queue
     input  logic [63:0]      data_i,             // data which is placed in the queue
     input  logic [1:0]       data_size_i,        // type of request we are making (e.g.: bytes to write)
+    input  logic             aq_i,
+    input  logic             rl_i,
     // D$
     output ariane_pkg::amo_req_t  amo_req_o,          // request to cache subsytem
     input  ariane_pkg::amo_resp_t amo_resp_i,         // response from cache subsystem
@@ -40,6 +42,8 @@ module amo_buffer (
         logic [riscv::PLEN-1:0] paddr;
         logic [63:0] data;
         logic [1:0]  size;
+        logic        aq;
+        logic        rl;
     } amo_op_t ;
 
     amo_op_t amo_data_in, amo_data_out;
@@ -50,11 +54,15 @@ module amo_buffer (
     assign amo_req_o.size = amo_data_out.size;
     assign amo_req_o.operand_a = {{64-riscv::PLEN{1'b0}}, amo_data_out.paddr};
     assign amo_req_o.operand_b = amo_data_out.data;
+    assign amo_req_o.aq = amo_data_out.aq;
+    assign amo_req_o.rl = amo_data_out.rl;
 
     assign amo_data_in.op = amo_op_i;
     assign amo_data_in.data = data_i;
     assign amo_data_in.paddr = paddr_i;
     assign amo_data_in.size = data_size_i;
+    assign amo_data_in.aq = aq_i;
+    assign amo_data_in.rl = rl_i;
 
     // only flush if we are currently not committing the AMO
     // e.g.: it is not speculative anymore

--- a/src/axi_shim.sv
+++ b/src/axi_shim.sv
@@ -33,6 +33,7 @@ module axi_shim #(
     input  logic [63:0]                     rd_addr_i,
     input  logic [$clog2(AxiNumWords)-1:0]  rd_blen_i, // axi convention: LEN-1
     input  logic [1:0]                      rd_size_i,
+    input  ariane_pkg::dcs_data_t           rd_dcs_data_i,
     input  logic [AxiIdWidth-1:0]           rd_id_i,   // use same ID for reads, or make sure you only have one outstanding read tx
     input  logic                            rd_lock_i,
     // read response (we have to unconditionally sink the response)
@@ -51,9 +52,12 @@ module axi_shim #(
     input  logic [AxiNumWords-1:0][7:0]     wr_be_i,
     input  logic [$clog2(AxiNumWords)-1:0]  wr_blen_i, // axi convention: LEN-1
     input  logic [1:0]                      wr_size_i,
+    input  ariane_pkg::dcs_data_t           wr_dcs_data_i,
     input  logic [AxiIdWidth-1:0]           wr_id_i,
     input  logic                            wr_lock_i,
     input  logic [5:0]                      wr_atop_i,
+    input  logic                            wr_aq_i,
+    input  logic                            wr_rl_i,
     // write response
     input  logic                            wr_rdy_i,
     output logic                            wr_valid_o,
@@ -83,6 +87,7 @@ module axi_shim #(
     assign axi_req_o.aw.burst  = (wr_single_req) ? 2'b00 : 2'b01;  // fixed size for single request and incremental transfer for everything else
     assign axi_req_o.aw.addr   = wr_addr_i;
     assign axi_req_o.aw.size   = wr_size_i;
+    assign axi_req_o.aw.user   = {wr_aq_i, wr_rl_i, wr_dcs_data_i};
     assign axi_req_o.aw.len    = wr_blen_i;
     assign axi_req_o.aw.id     = wr_id_i;
     assign axi_req_o.aw.prot   = 3'b0;
@@ -240,6 +245,7 @@ module axi_shim #(
                                                          2'b01;  
     assign axi_req_o.ar.addr   = rd_addr_i;
     assign axi_req_o.ar.size   = rd_size_i;
+    assign axi_req_o.ar.user   = {2'b0, rd_dcs_data_i};
     assign axi_req_o.ar.len    = rd_blen_i;
     assign axi_req_o.ar.id     = rd_id_i;
     assign axi_req_o.ar.prot   = {rd_instr_i, 2'b0};

--- a/src/cache_subsystem/wt_dcache.sv
+++ b/src/cache_subsystem/wt_dcache.sv
@@ -80,6 +80,7 @@ module wt_dcache #(
   logic [NumPorts-1:0][DCACHE_SET_ASSOC-1:0]    miss_vld_bits;
   logic [NumPorts-1:0][2:0]                     miss_size;
   logic [NumPorts-1:0][CACHE_ID_WIDTH-1:0]      miss_id;
+  dcs_data_t [NumPorts-1:0]                     miss_dcs_data;
   logic [NumPorts-1:0]                          miss_replay;
   logic [NumPorts-1:0]                          miss_rtrn_vld;
   logic [CACHE_ID_WIDTH-1:0]                    miss_rtrn_id;
@@ -134,6 +135,7 @@ module wt_dcache #(
     .miss_vld_bits_i    ( miss_vld_bits      ),
     .miss_size_i        ( miss_size          ),
     .miss_id_i          ( miss_id            ),
+    .miss_dcs_data_i    ( miss_dcs_data      ),
     .miss_replay_o      ( miss_replay        ),
     .miss_rtrn_vld_o    ( miss_rtrn_vld      ),
     .miss_rtrn_id_o     ( miss_rtrn_id       ),
@@ -187,6 +189,7 @@ module wt_dcache #(
       .miss_nc_o       ( miss_nc       [k] ),
       .miss_size_o     ( miss_size     [k] ),
       .miss_id_o       ( miss_id       [k] ),
+      .miss_dcs_data_o ( miss_dcs_data [k] ),
       .miss_replay_i   ( miss_replay   [k] ),
       .miss_rtrn_vld_i ( miss_rtrn_vld [k] ),
       // used to detect readout mux collisions
@@ -232,6 +235,7 @@ module wt_dcache #(
     .miss_nc_o       ( miss_nc       [2]   ),
     .miss_size_o     ( miss_size     [2]   ),
     .miss_id_o       ( miss_id       [2]   ),
+    .miss_dcs_data_o ( miss_dcs_data [2]   ),
     .miss_rtrn_vld_i ( miss_rtrn_vld [2]   ),
     .miss_rtrn_id_i  ( miss_rtrn_id        ),
     // cache read interface

--- a/src/cache_subsystem/wt_dcache_missunit.sv
+++ b/src/cache_subsystem/wt_dcache_missunit.sv
@@ -44,6 +44,7 @@ module wt_dcache_missunit #(
   input  logic [NumPorts-1:0][DCACHE_SET_ASSOC-1:0]  miss_vld_bits_i,
   input  logic [NumPorts-1:0][2:0]                   miss_size_i,
   input  logic [NumPorts-1:0][CACHE_ID_WIDTH-1:0]    miss_id_i,          // used as transaction ID
+  input  dcs_data_t [NumPorts-1:0]                   miss_dcs_data_i,
   // signals that the request collided with a pending read
   output logic [NumPorts-1:0]                        miss_replay_o,
   // signals response from memory
@@ -227,6 +228,9 @@ module wt_dcache_missunit #(
   assign mem_data_o.data   = (amo_sel) ? amo_data            : miss_wdata_i[miss_port_idx];
   assign mem_data_o.size   = (amo_sel) ? amo_req_i.size      : miss_size_i [miss_port_idx];
   assign mem_data_o.amo_op = (amo_sel) ? amo_req_i.amo_op    : AMO_NONE;
+  assign mem_data_o.dcs_data = (amo_sel) ? '0                : miss_dcs_data_i[miss_port_idx];
+  assign mem_data_o.aq     = (amo_sel) ? amo_req_i.aq        : '0;
+  assign mem_data_o.rl     = (amo_sel) ? amo_req_i.rl        : '0;
 
   assign tmp_paddr         = (amo_sel) ? amo_req_i.operand_a[riscv::PLEN-1:0] : miss_paddr_i[miss_port_idx];
   assign mem_data_o.paddr  = wt_cache_pkg::paddrSizeAlign(tmp_paddr, mem_data_o.size);

--- a/src/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/src/cache_subsystem/wt_dcache_wbuffer.sv
@@ -72,6 +72,7 @@ module wt_dcache_wbuffer #(
   output logic                               miss_nc_o,       // request to I/O space
   output logic [2:0]                         miss_size_o,     //
   output logic [CACHE_ID_WIDTH-1:0]          miss_id_o,       // ID of this transaction (wbuffer uses all IDs from 0 to DCACHE_MAX_TX-1)
+  output dcs_data_t                          miss_dcs_data_o,
   // write responses from memory
   input  logic                               miss_rtrn_vld_i,
   input  logic [CACHE_ID_WIDTH-1:0]          miss_rtrn_id_i,  // transaction ID to clear
@@ -172,6 +173,7 @@ module wt_dcache_wbuffer #(
   // add the offset to the physical base address of this buffer entry
   assign miss_paddr_o = {wbuffer_dirty_mux.wtag, bdirty_off};
   assign miss_id_o    = tx_id;
+  assign miss_dcs_data_o = wbuffer_dirty_mux.dcs_data;
 
   // is there any dirty word to be transmitted, and is there a free TX slot?
   assign miss_req_o = (|dirty) && free_tx_slots;
@@ -468,6 +470,9 @@ module wt_dcache_wbuffer #(
             wbuffer_d[wr_ptr].data[k*8 +: 8] = req_port_i.data_wdata[k*8 +: 8];
           end
         end
+
+        wbuffer_d[wr_ptr].dcs_data = req_port_i.dcs_data;
+
       end
     end
   end

--- a/src/issue_read_operands.sv
+++ b/src/issue_read_operands.sv
@@ -92,6 +92,9 @@ module issue_read_operands #(
     logic [TRANS_ID_BITS-1:0] trans_id_n, trans_id_q;
     fu_op operator_n, operator_q; // operation to perform
     fu_t  fu_n,       fu_q; // functional unit to use
+    logic use_dcs_n,  use_dcs_q;
+    logic aq_n, aq_q;
+    logic rl_n, rl_q;
 
     // forwarding signals
     logic forward_rs1, forward_rs2, forward_rs3;
@@ -107,6 +110,9 @@ module issue_read_operands #(
     assign fu_data_o.operator  = operator_q;
     assign fu_data_o.trans_id  = trans_id_q;
     assign fu_data_o.imm       = imm_q;
+    assign fu_data_o.use_dcs   = use_dcs_q;
+    assign fu_data_o.aq        = aq_q;
+    assign fu_data_o.rl        = rl_q;
     assign alu_valid_o         = alu_valid_q;
     assign branch_valid_o      = branch_valid_q;
     assign lsu_valid_o         = lsu_valid_q;
@@ -198,6 +204,9 @@ module issue_read_operands #(
         imm_n      = is_imm_fpr(issue_instr_i.op) ? operand_c_regfile : issue_instr_i.result;
         trans_id_n = issue_instr_i.trans_id;
         fu_n       = issue_instr_i.fu;
+        use_dcs_n  = issue_instr_i.use_dcs;
+        aq_n       = issue_instr_i.aq;
+        rl_n       = issue_instr_i.rl;
         operator_n = issue_instr_i.op;
         // or should we forward
         if (forward_rs1) begin
@@ -418,6 +427,9 @@ module issue_read_operands #(
             operand_b_q           <= '{default: 0};
             imm_q                 <= '0;
             fu_q                  <= NONE;
+            use_dcs_q             <= '0;
+            aq_q                  <= '0;
+            rl_q                  <= '0;
             operator_q            <= ADD;
             trans_id_q            <= '0;
             pc_o                  <= '0;
@@ -428,6 +440,9 @@ module issue_read_operands #(
             operand_b_q           <= operand_b_n;
             imm_q                 <= imm_n;
             fu_q                  <= fu_n;
+            use_dcs_q             <= use_dcs_n;
+            aq_q                  <= aq_n;
+            rl_q                  <= rl_n;
             operator_q            <= operator_n;
             trans_id_q            <= trans_id_n;
             pc_o                  <= issue_instr_i.pc;

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -72,6 +72,8 @@ module load_unit import ariane_pkg::*; #(
     assign req_port_o.address_tag   = paddr_i[ariane_pkg::DCACHE_TAG_WIDTH     +
                                               ariane_pkg::DCACHE_INDEX_WIDTH-1 :
                                               ariane_pkg::DCACHE_INDEX_WIDTH];
+    // assign dynamic coherence specialization
+    assign req_port_o.dcs_data = lsu_ctrl_i.dcs_data;
     // directly output an exception
     assign ex_o = ex_i;
 

--- a/src/store_buffer.sv
+++ b/src/store_buffer.sv
@@ -38,6 +38,7 @@ module store_buffer (
     input  logic [63:0]  data_i,          // data which is placed in the queue
     input  logic [7:0]   be_i,            // byte enable in
     input  logic [1:0]   data_size_i,     // type of request we are making (e.g.: bytes to write)
+    input  dcs_data_t    dcs_data_i,
 
     // D$ interface
     input  dcache_req_o_t req_port_i,
@@ -52,6 +53,7 @@ module store_buffer (
         logic [63:0]            data;
         logic [7:0]             be;
         logic [1:0]             data_size;
+        dcs_data_t              dcs_data;
         logic                   valid;     // this entry is valid, we need this for checking if the address offset matches
     } speculative_queue_n [DEPTH_SPEC-1:0], speculative_queue_q [DEPTH_SPEC-1:0],
       commit_queue_n [DEPTH_COMMIT-1:0],    commit_queue_q [DEPTH_COMMIT-1:0];
@@ -88,6 +90,7 @@ module store_buffer (
             speculative_queue_n[speculative_write_pointer_q].data      = data_i;
             speculative_queue_n[speculative_write_pointer_q].be        = be_i;
             speculative_queue_n[speculative_write_pointer_q].data_size = data_size_i;
+            speculative_queue_n[speculative_write_pointer_q].dcs_data  = dcs_data_i;
             speculative_queue_n[speculative_write_pointer_q].valid   = 1'b1;
             // advance the write pointer
             speculative_write_pointer_n = speculative_write_pointer_q + 1'b1;
@@ -137,6 +140,7 @@ module store_buffer (
     assign req_port_o.data_wdata    = commit_queue_q[commit_read_pointer_q].data;
     assign req_port_o.data_be       = commit_queue_q[commit_read_pointer_q].be;
     assign req_port_o.data_size     = commit_queue_q[commit_read_pointer_q].data_size;
+    assign req_port_o.dcs_data      = commit_queue_q[commit_read_pointer_q].dcs_data;
 
     always_comb begin : store_if
         automatic logic [DEPTH_COMMIT:0] commit_status_cnt;

--- a/src/store_unit.sv
+++ b/src/store_unit.sv
@@ -67,6 +67,9 @@ module store_unit (
     logic [63:0]  st_data_n,      st_data_q;
     logic [7:0]   st_be_n,        st_be_q;
     logic [1:0]   st_data_size_n, st_data_size_q;
+    dcs_data_t    st_dcs_data_n,  st_dcs_data_q;
+    logic         st_aq_n,        st_aq_q;
+    logic         st_rl_n,        st_rl_q;
     amo_t         amo_op_d,       amo_op_q;
 
     logic [TRANS_ID_BITS-1:0] trans_id_n, trans_id_q;
@@ -184,6 +187,9 @@ module store_unit (
         st_data_n = instr_is_amo ? lsu_ctrl_i.data
                                  : data_align(lsu_ctrl_i.vaddr[2:0], lsu_ctrl_i.data);
         st_data_size_n = extract_transfer_size(lsu_ctrl_i.operator);
+        st_dcs_data_n = lsu_ctrl_i.dcs_data;
+        st_aq_n = lsu_ctrl_i.aq;
+        st_rl_n = lsu_ctrl_i.rl;
         // save AMO op for next cycle
         case (lsu_ctrl_i.operator)
             AMO_LRW, AMO_LRD:     amo_op_d = AMO_LR;
@@ -235,6 +241,7 @@ module store_unit (
         .data_i                ( st_data_q              ),
         .be_i                  ( st_be_q                ),
         .data_size_i           ( st_data_size_q         ),
+        .dcs_data_i            ( st_dcs_data_q          ),
         .req_port_i            ( req_port_i             ),
         .req_port_o            ( req_port_o             )
     );
@@ -249,6 +256,8 @@ module store_unit (
         .amo_op_i           ( amo_op_q           ),
         .data_i             ( st_data_q          ),
         .data_size_i        ( st_data_size_q     ),
+        .aq_i               ( st_aq_q            ),
+        .rl_i               ( st_rl_q            ),
         .amo_req_o          ( amo_req_o          ),
         .amo_resp_i         ( amo_resp_i         ),
         .amo_valid_commit_i ( amo_valid_commit_i ),
@@ -264,6 +273,7 @@ module store_unit (
             st_be_q        <= '0;
             st_data_q      <= '0;
             st_data_size_q <= '0;
+            st_dcs_data_q  <= '0;
             trans_id_q     <= '0;
             amo_op_q       <= AMO_NONE;
         end else begin
@@ -272,7 +282,10 @@ module store_unit (
             st_data_q      <= st_data_n;
             trans_id_q     <= trans_id_n;
             st_data_size_q <= st_data_size_n;
+            st_dcs_data_q  <= st_dcs_data_n;
             amo_op_q       <= amo_op_d;
+            st_aq_q        <= st_aq_n;
+            st_rl_q        <= st_rl_n;
         end
     end
 

--- a/src/util/axi_master_connect.sv
+++ b/src/util/axi_master_connect.sv
@@ -28,7 +28,7 @@ module axi_master_connect (
     assign master.aw_qos        = axi_req_i.aw.qos;
     assign master.aw_atop       = axi_req_i.aw.atop;
     assign master.aw_region     = axi_req_i.aw.region;
-    assign master.aw_user       = '0;
+    assign master.aw_user       = axi_req_i.aw.user;
     assign master.aw_valid      = axi_req_i.aw_valid;
     assign axi_resp_o.aw_ready  = master.aw_ready;
 
@@ -54,7 +54,7 @@ module axi_master_connect (
     assign master.ar_prot       = axi_req_i.ar.prot;
     assign master.ar_qos        = axi_req_i.ar.qos;
     assign master.ar_region     = axi_req_i.ar.region;
-    assign master.ar_user       = '0;
+    assign master.ar_user       = axi_req_i.ar.user;
     assign master.ar_valid      = axi_req_i.ar_valid;
     assign axi_resp_o.ar_ready  = master.ar_ready;
 


### PR DESCRIPTION
This PR includes ISA extension for Ariane that Spandex uses to deliver cache-coherence-related performance hints to underlying Spandex caches, via the standard AXI bus USER field.

Part of this work is credited to Robert Jin @GingerJin0114