### PR TITLE
remove sync from scoreboard_entry_t

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -607,7 +607,6 @@ package ariane_pkg;
         logic [REG_ADDR_SIZE-1:0] rs1;           // register source address 1
         logic [REG_ADDR_SIZE-1:0] rs2;           // register source address 2
         logic [REG_ADDR_SIZE-1:0] rd;            // register destination address
-        logic                     sync;
         logic [63:0]              result;        // for unfinished instructions this field also holds the immediate,
                                                  // for unfinished floating-point that are partly encoded in rs2, this field also holds rs2
                                                  // for unfinished floating-point fused operations (FMADD, FMSUB, FNMADD, FNMSUB)


### PR DESCRIPTION
Removing unnecessary signal `sync` from `scoreboard_entry_t`. This was originally added in https://github.com/sld-columbia/ariane/commit/c5e76c8edc5fb7da1c0e0b4386dada5a52121ea9 but not required anymore.